### PR TITLE
ElasticsearchThreadPoolUtilisationWarning

### DIFF
--- a/mixin/alerts/alerts.libsonnet
+++ b/mixin/alerts/alerts.libsonnet
@@ -95,7 +95,7 @@
             },
             annotations: {
               summary: 'High threadpool utilisation',
-              message: 'Cluster {{ $labels.cluster }} threadpool utilisation > %(esClusterThreadpoolRatio)s for  %(esClusterThreadpoolTime)s' % custom.alert,
+              message: 'Cluster {{ $labels.cluster }} threadpool utilisation > %(esClusterThreadpoolRatio)s for %(esClusterThreadpoolTime)s' % custom.alert,
             },
           },
           //{

--- a/mixin/alerts/alerts.libsonnet
+++ b/mixin/alerts/alerts.libsonnet
@@ -75,6 +75,29 @@
               message: 'Cluster {{ $labels.cluster }} health status has been YELLOW for at least %(esClusterHealthStatusYELLOW)s. Some shard replicas are not allocated.' % custom.alert,
             },
           },
+          {
+            alert: 'ElasticsearchThreadPoolUtilisationWarning',
+            // Total threadpool utilisation exceeds CPU count
+            expr: |||
+              sum by (cluster) (
+                :elasticsearch_threadpool_utilisation:sum_rate{%(selector)s}
+              )
+              /
+              sum by (cluster) (
+                sum without (host, name) (
+                  elasticsearch_thread_pool_threads_count{type="write", %(selector)s}
+                )
+              ) > %(esClusterThreadpoolRatio)s
+            ||| % custom.alert,
+            'for': '%(esClusterThreadpoolTime)s' % custom.alert,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'High threadpool utilisation',
+              message: 'Cluster {{ $labels.cluster }} threadpool utilisation > %(esClusterThreadpoolRatio)s for  %(esClusterThreadpoolTime)s' % custom.alert,
+            },
+          },
           //{
           //  alert: 'ElasticsearchBulkRequestsRejectionJumps',
           //  expr: |||
@@ -91,8 +114,6 @@
           //},
         ],
       },
-
-
     ],
   },
 }

--- a/mixin/config.libsonnet
+++ b/mixin/config.libsonnet
@@ -5,6 +5,8 @@
     esDiskHighWaterMark: 0.9,
     esClusterHealthStatusRED: '2m',
     esClusterHealthStatusYELLOW: '20m',
+    esClusterThreadpoolRatio: 1,
+    esClusterThreadpoolTime: '20m',
   },
   rule+:: {
     selector: 'job=~"elasticsearch.*"',

--- a/mixin/rules/rules.libsonnet
+++ b/mixin/rules/rules.libsonnet
@@ -1,5 +1,34 @@
 {
+  local custom = self,
+  alert+:: {
+    selector: error 'must provide selector for Elasticsearch alerts',
+  },
   prometheusRules+:: {
-
+    groups+: [
+      {
+        name: 'elasticsearch.application.rules'
+        rules: [
+          {
+            // Default configuration, is write threads to match the number of CPU cores available
+            // We record the ratio of threadpool usage against available CPU in the cluster.
+            // hot-warm-cold architecture may need some additional labels for this to be useful.
+            record: ':elasticsearch_threadpool_utilisation:sum_rate',
+            expr: |||
+              sum by (cluster, type) (
+                sum without (host, name) (
+                  elasticsearch_thread_pool_active_count{%(selector)s}
+                )
+              )
+              /
+              sum by (cluster, type) (
+                sum without (host, name) (
+                  elasticsearch_thread_pool_threads_count{%(selector)s}
+                )
+              )
+            ||| % custom.alert,
+          },
+        ],
+      },
+    ],
   },
 }

--- a/mixin/rules/rules.libsonnet
+++ b/mixin/rules/rules.libsonnet
@@ -6,7 +6,7 @@
   prometheusRules+:: {
     groups+: [
       {
-        name: 'elasticsearch.application.rules'
+        name: 'elasticsearch.application.rules',
         rules: [
           {
             // Default configuration, is write threads to match the number of CPU cores available


### PR DESCRIPTION
## Context

Thread pool utilisation alert.

### Changes

Adding recordig rule for threadpool utilisation and an alert for when total thread pool usage exceeds the number of available CPUs.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
