### PR TITLE
Add extra selector for ElasticsearchNodeDiskWatermarkReached alert tofix false positives

### DIFF
--- a/mixin/alerts/alerts.libsonnet
+++ b/mixin/alerts/alerts.libsonnet
@@ -15,7 +15,7 @@
             alert: 'ElasticsearchNodeDiskWatermarkReached',
             expr: |||
               max by (cluster, instance, node,%(extraLabels)s) (
-                1 - (elasticsearch_filesystem_data_free_bytes{%(selector)s} / elasticsearch_filesystem_data_size_bytes{%(selector)s})
+                1 - (elasticsearch_filesystem_data_free_bytes{es_data_node="true", %(selector)s} / elasticsearch_filesystem_data_size_bytes{es_data_node="true", %(selector)s})
               ) > %(esDiskLowWaterMark)s
             ||| % custom.alert,
             'for': '5m',
@@ -31,7 +31,7 @@
             alert: 'ElasticsearchNodeDiskWatermarkReached',
             expr: |||
               max by (cluster, instance, node,%(extraLabels)s) (
-                1 - (elasticsearch_filesystem_data_free_bytes{%(selector)s} / elasticsearch_filesystem_data_size_bytes{%(selector)s})
+                1 - (elasticsearch_filesystem_data_free_bytes{es_data_node="true", %(selector)s} / elasticsearch_filesystem_data_size_bytes{es_data_node="true", %(selector)s})
               ) > %(esDiskHighWaterMark)s
             ||| % custom.alert,
             'for': '5m',


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
We have gotten some false positive alerts from master nodes, but master nodes don't hold data. So this alert shouldn't be applied to non-data nodes.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
